### PR TITLE
Improve SystemHistoryView, AnimationMapDatabase plots

### DIFF
--- a/tathu/visualizer.py
+++ b/tathu/visualizer.py
@@ -121,6 +121,8 @@ class SystemHistoryView:
         ncols = 6
         n = len(self.family.systems)
         nlines = int(n / ncols + 1)
+        # Define size of figure according to ncols/nlines
+        plt.gcf().set_size_inches(ncols*2, nlines*2, forward=True)
 
         # Create individual plots
         i = 0
@@ -343,6 +345,9 @@ class AnimationMapDatabase(animation.TimedAnimation):
 
         plt.legend(handles=patchList, loc='upper right')
 
+        # Add title
+        self.map.set_title(self.timestamps[0].strftime("%Y-%m-%d %H:%M:%S UTC"))
+
         animation.TimedAnimation.__init__(self, fig, interval=500, blit=False, repeat_delay=2000)
 
     def show(self):
@@ -357,6 +362,9 @@ class AnimationMapDatabase(animation.TimedAnimation):
 
         # Update image
         self.array.set_array(self.__getArray(self.images[i]))
+
+        # Update title
+        self.map.set_title(self.timestamps[i].strftime("%Y-%m-%d %H:%M:%S UTC"))
 
         # Load systems
         systems = self.db.loadByDate('%Y%m%d%H%M', self.timestamps[i].strftime('%Y%m%d%H%M'), attrs=['nae'])


### PR DESCRIPTION
I have two suggestions for the visualizations based on my use with radar data:

1. In `SystemHistoryView`, the standard figure size is too small in both short and long families (maybe because of the smaller extent of the radar data compared to satellite?). Examples:
![old short family](https://i.imgur.com/I2uQspL.png) 
![old long family](https://i.imgur.com/XIhlzxv.png)

To make sure the figure size is adaptable in both situations, I modified it with `plt.gcf().set_size_inches()` based on the number of lines/columns. The same families above plotted with this code:
![new short family](https://i.imgur.com/rNd70C9.png)
![new long family](https://i.imgur.com/MQF2OWW.png)

**Be aware that I didn't test it with satellite data.**

2. In `AnimationMapDatabase`, I thought it would be interesting to add a title with the timestamp of each figure. Example of animation with timestamp [here](https://i.imgur.com/VDwrgmy.mp4).