### PR TITLE
Improving MapView centroids plot

### DIFF
--- a/tathu/visualizer.py
+++ b/tathu/visualizer.py
@@ -60,7 +60,7 @@ class MapView(object):
         polygons = [s.geom for s in systems]
         self.plotPolygons(polygons, facecolor, alpha, edgecolor, lw, centroids)
 
-    def plotPolygons(self, polygons, facecolor='red', alpha=1.0, edgecolor='k', lw=1.0, centroids=False):
+    def plotPolygons(self, polygons, facecolor='red', edgecolor='k', alpha=1.0, lw=1.0, centroids=False):
         # Centroid coordinates
         x, y = [], []
         for p in polygons:
@@ -77,7 +77,7 @@ class MapView(object):
             self.__plotPolygon(lats, lons, facecolor, alpha, lw, edgecolor)
 
         # Show centroids
-        self.ax.scatter(x, y, marker='.', color='b')
+        self.ax.scatter(x, y, marker='o', facecolor=facecolor, edgecolor=edgecolor, alpha=alpha)
 
     def __plotPolygon(self, lats, lons, facecolor, alpha, lw, edgecolor):
         xy = list(zip(lons, lats))


### PR DESCRIPTION
Considering that the `MapView` class can be used to plot diagnostics with the forecasts in a map, it would be interesting (at least in this case) to use the same facecolor/edgecolor/alpha for the polygons and the centroid points in order to match the polygons with the centroids. It's hard to distinguish the centroids in the figure below, for example.

![example](https://i.imgur.com/zNHeVUK.png)

Feel free to modify it if you think it's better to use this setting only in this "multiplot" case.